### PR TITLE
[Bugfix] Disabled setOptions

### DIFF
--- a/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Manager/SubscriptionManager.swift
+++ b/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Manager/SubscriptionManager.swift
@@ -55,8 +55,6 @@ final class SubscriptionManager {
                 self.makeCredentials(streamName: streamName, accountID: accountID)
             )
 
-//            subscriber.setOptions(self.clientOptions)
-
             guard subscriber.connect() else {
                 Self.logger.debug("Failed to connect")
                 return false


### PR DESCRIPTION
- Opted out setOptions since it breaks `onStatsReport`. The only option it's been used for `statsDelayMs` isn't implemented yet.