### PR TITLE
Start streaming after select a recent stream

### DIFF
--- a/RTSViewer/RecentStreamsScreen/RecentStreamsScreen.swift
+++ b/RTSViewer/RecentStreamsScreen/RecentStreamsScreen.swift
@@ -11,14 +11,19 @@ struct RecentStreamsScreen: View {
     @Binding private var accountID: String
     @Binding private var isShowingRecentStreams: Bool
     @EnvironmentObject private var dataStore: RTSDataStore
+
+    let action: (() -> Void)?
+
     private let theme = ThemeManager.shared.theme
 
     private let streamDetails: FetchRequest<StreamDetail> = FetchRequest<StreamDetail>(fetchRequest: PersistenceManager.recentStreams)
 
-    init(streamName: Binding<String>, accountID: Binding<String>, isShowingRecentStreams: Binding<Bool>) {
+    init(streamName: Binding<String>, accountID: Binding<String>,
+         isShowingRecentStreams: Binding<Bool>, _ action: (() -> Void)?) {
         self._streamName = streamName
         self._accountID = accountID
         self._isShowingRecentStreams = isShowingRecentStreams
+        self.action = action
     }
 
     var body: some View {
@@ -78,6 +83,7 @@ struct RecentStreamsScreen: View {
                                     self.streamName = streamName
                                     self.accountID = accountID
                                     isShowingRecentStreams = false
+                                    action?()
                                 }
                             }
                         }
@@ -93,6 +99,6 @@ struct RecentStreamsScreen: View {
 
 struct StreamHistoryScreen_Previews: PreviewProvider {
     static var previews: some View {
-        RecentStreamsScreen(streamName: .constant(""), accountID: .constant(""), isShowingRecentStreams: .constant(false))
+        RecentStreamsScreen(streamName: .constant(""), accountID: .constant(""), isShowingRecentStreams: .constant(false)) { }
     }
 }

--- a/RTSViewer/StreamDetailInputScreen/StreamDetailInputScreen.swift
+++ b/RTSViewer/StreamDetailInputScreen/StreamDetailInputScreen.swift
@@ -14,6 +14,8 @@ struct StreamDetailInputScreen: View {
     @State private var isShowingStreamingView: Bool = false
     @State private var isShowingRecentStreams: Bool = false
 
+    @EnvironmentObject private var dataStore: RTSDataStore
+
     var body: some View {
         BackgroundContainerView {
             ZStack {
@@ -45,8 +47,14 @@ struct StreamDetailInputScreen: View {
                     RecentStreamsScreen(
                         streamName: $streamName,
                         accountID: $accountID,
-                        isShowingRecentStreams: $isShowingRecentStreams
-                    )
+                        isShowingRecentStreams: $isShowingRecentStreams) {
+                            Task.delayed(byTimeInterval: 0.5) {
+                                let success = await dataStore.connect(streamName: streamName, accountID: accountID)
+                                await MainActor.run {
+                                    isShowingStreamingView = success
+                                }
+                            }
+                        }
                 }
             }
         }

--- a/RTSViewer/StreamingScreen/AnyGestureRecognizer.swift
+++ b/RTSViewer/StreamingScreen/AnyGestureRecognizer.swift
@@ -45,6 +45,7 @@ struct AnyGestureRecognizer: UIViewRepresentable {
         init(recognizer: AnyGestureRecognizer) {
             parent = recognizer
         }
+
         func clicked() {
             trigger()
         }
@@ -71,6 +72,7 @@ struct AnyGestureRecognizer: UIViewRepresentable {
             }
         }
     }
+
     class AnyGestureView: UIView {
         weak var delegate: Coordinator?
 

--- a/RTSViewer/StreamingScreen/StreamingScreen.swift
+++ b/RTSViewer/StreamingScreen/StreamingScreen.swift
@@ -29,12 +29,12 @@ struct StreamingScreen: View {
     var body: some View {
         BackgroundContainerView {
             ZStack {
-                VideoRendererView(uiView: dataStore.subscriptionView()).brightness(showSettings ? -0.25 : 0)
+                VideoRendererView(uiView: dataStore.subscriptionView())
 
                 VStack {}
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Color.black)
-                    .opacity(isStreamActive ? 0.0 : 0.8)
+                    .opacity(isStreamActive ? (showToolbar ? 0.5: 0.0) : 0.8)
 
                 if persistentSettings.liveIndicatorEnable {
                     VStack {
@@ -109,6 +109,7 @@ struct StreamingScreen: View {
 
                     }
                 }
+
                 if showStats {
                     StatisticsView(statsView: $showStats, stats: $dataStore.statisticsData)
                 }


### PR DESCRIPTION
After selecting a recent store stream name and account ID pair. Start the stream monitoring immediately.
Dim the stream screen when the Settings icon appears