### PR TITLE
UI fixes for iPad (Part 1)

### DIFF
--- a/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Components/NavigationHeaderView/NavigationHeaderView.swift
+++ b/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Components/NavigationHeaderView/NavigationHeaderView.swift
@@ -10,7 +10,9 @@ public extension View {
         self.safeAreaInset(edge: .top) {
             NavigationHeaderView()
         }
+#if os(tvOS)
         .ignoresSafeArea()
+#endif
     }
 }
 

--- a/RTSViewer/RecentStreamsScreen/RecentStreamsScreen.swift
+++ b/RTSViewer/RecentStreamsScreen/RecentStreamsScreen.swift
@@ -74,8 +74,9 @@ struct RecentStreamsScreen: View {
                             )
                     }
                     .padding([.leading, .trailing])
+ #if os(tvOS)
                     .frame(width: 514.0)
-
+ #endif
                     List {
                         ForEach(streamDetails.wrappedValue) { streamDetail in
                             if let streamName = streamDetail.streamName, let accountID = streamDetail.accountID {
@@ -88,7 +89,9 @@ struct RecentStreamsScreen: View {
                             }
                         }
                     }
+ #if os(tvOS)
                     .frame(width: 514.0)
+ #endif
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }

--- a/RTSViewer/StreamingScreen/StreamingScreen.swift
+++ b/RTSViewer/StreamingScreen/StreamingScreen.swift
@@ -37,6 +37,7 @@ struct StreamingScreen: View {
                     .background(Color.black)
                     .opacity(isStreamActive ? (showToolbar ? 0.5: 0.0) : 0.8)
 
+#if os(tvOS)
                 if persistentSettings.liveIndicatorEnable {
                     VStack {
                         HStack {
@@ -56,6 +57,7 @@ struct StreamingScreen: View {
                         .padding(.leading, 56)
                         .padding(.top, 37)
                 }
+#endif
 
                 if isStreamActive {
                     if showToolbar {
@@ -73,7 +75,9 @@ struct StreamingScreen: View {
                         .padding()
                         .transition(.move(edge: .bottom))
                     } else {
+#if os(tvOS)
                         AnyGestureRecognizer(triggered: $showToolbar)
+#endif
                     }
                 }
 


### PR DESCRIPTION
Changes: 
- NavigationHeaderView - to fit into safe area 
- RecentStreamsScreen to fit into screen
- StreamingScreen: hidden live indicator (except tvOS)