### PR TITLE
Bottom copyright text

### DIFF
--- a/RTSViewer/iOS/RecentStreams/RecentStreamsScreen.swift
+++ b/RTSViewer/iOS/RecentStreams/RecentStreamsScreen.swift
@@ -127,15 +127,6 @@ struct RecentStreamsScreen: View {
                         text: "recent-streams.play-new.button"
                     )
                     .frame(maxWidth: 400)
-
-                    Spacer()
-
-                    VStack {
-                        FooterView(text: "recent-streams.footnote.label")
-
-                        Spacer()
-                            .frame(height: Layout.spacing1x)
-                    }
                 }
             }
             .layoutPriority(1)
@@ -146,6 +137,9 @@ struct RecentStreamsScreen: View {
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     IconView(name: .dolby_logo_dd, tintColor: .white)
+                }
+                ToolbarItem(placement: .bottomBar) {
+                    FooterView(text: "recent-streams.footnote.label")
                 }
             }
             .onAppear {

--- a/RTSViewer/iOS/StreamDetailInputScreen/StreamDetailInputScreen.swift
+++ b/RTSViewer/iOS/StreamDetailInputScreen/StreamDetailInputScreen.swift
@@ -110,13 +110,6 @@ struct StreamDetailInputScreen: View {
                 .frame(maxWidth: 400)
 
                 Spacer()
-                    .frame(minHeight: Layout.spacing2x)
-
-                FooterView(text: "stream-detail-input.footnote.label")
-
-                Spacer()
-                    .frame(height: Layout.spacing1x)
-
             }
             .padding([.leading, .trailing], Layout.spacing3x)
         }
@@ -128,8 +121,13 @@ struct StreamDetailInputScreen: View {
                     })
                 }
             }
+
             ToolbarItem(placement: .principal) {
                 IconView(name: .dolby_logo_dd, tintColor: .white)
+            }
+
+            ToolbarItem(placement: .bottomBar) {
+                FooterView(text: "stream-detail-input.footnote.label")
             }
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
Fix copyright text is not at the bottom and move up if keyboard pop-up