### PR TITLE
Handle for network connection errors

### DIFF
--- a/RTSViewer/iOS/StreamingScreen/StreamingScreen.swift
+++ b/RTSViewer/iOS/StreamingScreen/StreamingScreen.swift
@@ -32,7 +32,7 @@ struct StreamingScreen: View {
                 VStack {}
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .background(Color.black)
-                    .opacity(viewModel.isStreamActive ? (showToolbar ? 0.5: 0.0) : 0.8)
+                    .opacity(viewModel.isStreamActive && viewModel.isNetworkConnected ? (showToolbar ? 0.5: 0.0) : 0.8)
             }
             .edgesIgnoringSafeArea(.all)
             .onReceive(viewModel.$isStreamActive) { isStreamActive in
@@ -63,10 +63,9 @@ struct StreamingScreen: View {
                     dataStore: viewModel.dataStore
                 )
             }
-            if !viewModel.isStreamActive {
+            if !viewModel.isStreamActive || !viewModel.isNetworkConnected {
                 StreamConnectionView(isNetworkConnected: viewModel.isNetworkConnected)
             }
-
         }
         .onAppear {
             UIApplication.shared.isIdleTimerDisabled = viewModel.isStreamActive


### PR DESCRIPTION
Description:

Shows a network connection error on screen when network connectivity is lost while playing a stream

Note:
The SDK delegate methods are not called when a connection error occur. It is also observed that regaining the connection within a short time automatically restarts the frozen stream. If the connection is regained after a longer time - the stream is frozen for ever, means the user have to close and play again.