### PR TITLE
Listview in the app

### DIFF
--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -144,7 +144,7 @@ final class StreamSourceBuilder {
 extension StreamSourceBuilder {
     var hasMissingAudioTrack: Bool {
         let audioTrackItems = supportedTrackItems.filter { $0.mediaType == .audio }
-        return audioTrackItems.count < audioTracks.count
+        return audioTracks.count < audioTrackItems.count
     }
 
     var hasMissingVideoTrack: Bool {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -43,7 +43,7 @@ final class StreamSourceBuilder {
     private(set) var preferredVideoQuality: StreamSource.VideoQuality = .auto
     private(set) var isPlayingAudio = false
     private(set) var isPlayingVideo = false
-    private(set) var dimensions: StreamSource.Dimensions = StreamSource.Dimensions(width: 533, height: 300)
+    private(set) var dimensions: CGSize = CGSize(width: 533, height: 300)
 
     init(streamId: String, sourceId: String?, tracks: [String]) {
         identifier = UUID()
@@ -106,8 +106,8 @@ final class StreamSourceBuilder {
         isPlayingVideo = enable
     }
 
-    func setDimensions(width: Float, height: Float) {
-        dimensions = StreamSource.Dimensions(width: width, height: height)
+    func setDimensions(width: CGFloat, height: CGFloat) {
+        dimensions = CGSize(width: width, height: height)
     }
 
     func build() throws -> StreamSource {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -43,6 +43,7 @@ final class StreamSourceBuilder {
     private(set) var preferredVideoQuality: StreamSource.VideoQuality = .auto
     private(set) var isPlayingAudio = false
     private(set) var isPlayingVideo = false
+    private(set) var dimensions: StreamSource.Dimensions = StreamSource.Dimensions(width: 533, height: 300)
 
     init(streamId: String, sourceId: String?, tracks: [String]) {
         identifier = UUID()
@@ -105,6 +106,10 @@ final class StreamSourceBuilder {
         isPlayingVideo = enable
     }
 
+    func setDimensions(width: Float, height: Float) {
+        dimensions = StreamSource.Dimensions(width: width, height: height)
+    }
+
     func build() throws -> StreamSource {
         guard !hasMissingAudioTrack else {
             throw BuildError.missingAudioTrack
@@ -123,7 +128,9 @@ final class StreamSourceBuilder {
             isPlayingAudio: isPlayingAudio,
             isPlayingVideo: isPlayingVideo,
             audioTracks: audioTracks,
-            videoTrack: videoTrack
+            videoTrack: videoTrack,
+            width: dimensions.width,
+            height: dimensions.height
         )
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
@@ -193,7 +193,7 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
             return
         }
 
-        Self.configureAudioSession(isSubscriber: true)
+        Utils.configureAudioSession()
         let projectionData = MCProjectionData()
         audioTrack.track.enable(true)
         audioTrack.track.setVolume(1)
@@ -202,24 +202,6 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
         projectionData.trackId = audioTrack.trackInfo.trackType.rawValue
 
         subscriber.project(source.sourceId.value, withData: [projectionData])
-    }
-
-    private static func configureAudioSession(isSubscriber: Bool = false) {
-        let session = AVAudioSession.sharedInstance()
-        do {
-            #if os(iOS)
-            // For subscriber, we only need playback. Not recording is required.
-            try session.setCategory(isSubscriber ? .playback : .playAndRecord,
-                                    mode: .videoChat,
-                                    options: [.mixWithOthers])
-            #else
-            try session.setCategory(.playback, options: [.mixWithOthers])
-            #endif
-            try session.setActive(true)
-        } catch {
-            print("Failed audio session: \(error)")
-            return
-        }
     }
 
     func unprojectAudio(for source: StreamSource) {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
@@ -5,6 +5,7 @@
 import Foundation
 import MillicastSDK
 import os
+import AVFAudio
 
 protocol SubscriptionManagerDelegate: AnyObject {
     func onSubscribed()
@@ -192,12 +193,33 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
             return
         }
 
+        Self.configureAudioSession(isSubscriber: true)
         let projectionData = MCProjectionData()
+        audioTrack.track.enable(true)
+        audioTrack.track.setVolume(1)
         projectionData.media = audioTrack.trackInfo.mediaType.rawValue
         projectionData.mid = audioTrack.trackInfo.mid
         projectionData.trackId = audioTrack.trackInfo.trackType.rawValue
 
         subscriber.project(source.sourceId.value, withData: [projectionData])
+    }
+
+    private static func configureAudioSession(isSubscriber: Bool = false) {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            #if os(iOS)
+            // For subscriber, we only need playback. Not recording is required.
+            try session.setCategory(isSubscriber ? .playback : .playAndRecord,
+                                    mode: .videoChat,
+                                    options: [.mixWithOthers])
+            #else
+            try session.setCategory(.playback, options: [.mixWithOthers])
+            #endif
+            try session.setActive(true)
+        } catch {
+            print("Failed audio session: \(error)")
+            return
+        }
     }
 
     func unprojectAudio(for source: StreamSource) {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSource.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSource.swift
@@ -99,16 +99,6 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         }
     }
 
-    public struct Dimensions {
-        public let width: Float
-        public let height: Float
-
-        public init(width: Float, height: Float) {
-            self.width = width
-            self.height = height
-        }
-    }
-
     public let id: UUID
     public let streamId: String
     public let sourceId: SourceId
@@ -118,6 +108,6 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
     public let isPlayingVideo: Bool
     let audioTracks: [AudioTrackInfo]
     let videoTrack: VideoTrackInfo?
-    public let width: Float
-    public let height: Float
+    public let width: CGFloat
+    public let height: CGFloat
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSource.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSource.swift
@@ -99,6 +99,16 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         }
     }
 
+    public struct Dimensions {
+        public let width: Float
+        public let height: Float
+
+        public init(width: Float, height: Float) {
+            self.width = width
+            self.height = height
+        }
+    }
+
     public let id: UUID
     public let streamId: String
     public let sourceId: SourceId
@@ -108,4 +118,6 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
     public let isPlayingVideo: Bool
     let audioTracks: [AudioTrackInfo]
     let videoTrack: VideoTrackInfo?
+    public let width: Float
+    public let height: Float
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
@@ -12,20 +12,40 @@ public protocol SourceViewProviding {
     var frameHeight: CGFloat { get }
 }
 
-struct StreamSourceViewProvider {
-    let renderer: MCIosVideoRenderer
+class StreamSourceViewProvider {
+//    let renderer: MCIosVideoRenderer
+    var renderer: MCIosVideoRenderer?
+    var view: UIView?
+    let track: MCVideoTrack
+//    init(renderer: MCIosVideoRenderer) {
+//        print("+++++++++++> renderer created: \(renderer)")
+//        self.renderer = renderer
+//    }
+    init(_ track: MCVideoTrack) {
+        self.track = track
+    }
 }
 
 extension StreamSourceViewProvider: SourceViewProviding {
     var frameWidth: CGFloat {
-        CGFloat(renderer.getWidth())
+        CGFloat(renderer?.getWidth() ?? 0)
     }
 
     var frameHeight: CGFloat {
-        CGFloat(renderer.getHeight())
+        CGFloat(renderer?.getHeight() ?? 0)
     }
 
     var playbackView: UIView {
-        renderer.getView()
+        if let view = self.view {
+            return view
+        } else {
+            let renderer = MCIosVideoRenderer()
+            track.add(renderer)
+            let view: UIView = renderer.getView()
+            self.view = view
+            self.renderer = renderer
+            print("+++++++++++> view created: \(view)")
+            return view
+        }
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
@@ -13,38 +13,28 @@ public protocol SourceViewProviding {
 }
 
 class StreamSourceViewProvider {
-//    let renderer: MCIosVideoRenderer
-    var renderer: MCIosVideoRenderer?
+    var renderer: MCIosVideoRenderer
     var view: UIView?
-    let track: MCVideoTrack
-//    init(renderer: MCIosVideoRenderer) {
-//        print("+++++++++++> renderer created: \(renderer)")
-//        self.renderer = renderer
-//    }
-    init(_ track: MCVideoTrack) {
-        self.track = track
+    init(renderer: MCIosVideoRenderer) {
+        self.renderer = renderer
     }
 }
 
 extension StreamSourceViewProvider: SourceViewProviding {
     var frameWidth: CGFloat {
-        CGFloat(renderer?.getWidth() ?? 0)
+        CGFloat(renderer.getWidth() )
     }
 
     var frameHeight: CGFloat {
-        CGFloat(renderer?.getHeight() ?? 0)
+        CGFloat(renderer.getHeight() )
     }
 
     var playbackView: UIView {
         if let view = self.view {
             return view
         } else {
-            let renderer = MCIosVideoRenderer()
-            track.add(renderer)
             let view: UIView = renderer.getView()
             self.view = view
-            self.renderer = renderer
-            print("+++++++++++> view created: \(view)")
             return view
         }
     }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Model/StreamSourceViewProvider.swift
@@ -22,20 +22,14 @@ class StreamSourceViewProvider {
 
 extension StreamSourceViewProvider: SourceViewProviding {
     var frameWidth: CGFloat {
-        CGFloat(renderer.getWidth() )
+        CGFloat(renderer.getWidth())
     }
 
     var frameHeight: CGFloat {
-        CGFloat(renderer.getHeight() )
+        CGFloat(renderer.getHeight())
     }
 
     var playbackView: UIView {
-        if let view = self.view {
-            return view
-        } else {
-            let view: UIView = renderer.getView()
-            self.view = view
-            return view
-        }
+        renderer.getView()
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Utils/Utils.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSCore/Utils/Utils.swift
@@ -1,0 +1,27 @@
+//
+//  Utils.swift
+//
+
+import AVFAudio
+import Foundation
+
+/**
+ * Utility methods used in the SA.
+ */
+class Utils {
+    public static func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+#if os(iOS)
+            // For subscriber, we only need playback. Not recording is required.
+            try session.setCategory(.playback, mode: .videoChat, options: [.mixWithOthers])
+#else
+            try session.setCategory(.playback, options: [.mixWithOthers])
+#endif
+            try session.setActive(true)
+        } catch {
+            print("Failed audio session: \(error)")
+            return
+        }
+    }
+}

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -8,14 +8,16 @@ import DolbyIORTSCore
 
 struct ListView: View {
     private var viewModel: StreamViewModel
+    private var highlightedIndex: Int
     private var selectedSourceIndex: Int
     private var onSelectedSourceIndexChange: (Int) -> Void
     private var onSelectedSourceClick: () -> Void
 
     let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
 
-    init(viewModel: StreamViewModel, selectedSourceIndex: Int, onSelectedSourceIndexChange: @escaping (Int) -> Void, onSelectedSourceClick: @escaping () -> Void) {
+    init(viewModel: StreamViewModel, highlightedIndex: Int, selectedSourceIndex: Int, onSelectedSourceIndexChange: @escaping (Int) -> Void, onSelectedSourceClick: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.highlightedIndex = highlightedIndex
         self.selectedSourceIndex = selectedSourceIndex
         self.onSelectedSourceIndexChange = onSelectedSourceIndexChange
         self.onSelectedSourceClick = onSelectedSourceClick
@@ -27,9 +29,15 @@ struct ListView: View {
                 let w = Float(geometry.size.width)
                 let h = Float(geometry.size.height) / 3
                 if let videoSource = videoSourceFrom(index: selectedSourceIndex),
-                    let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource) {
+                   let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource) {
                     let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: videoSource.width, height: videoSource.height), frameWidth: w, frameHeight: h)
-                    VideoRendererView(viewProvider: viewProvider).frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
+                    VideoRendererView(viewProvider: viewProvider)
+                        .overlay(highlightedIndex == selectedSourceIndex ? Rectangle()
+                            .stroke(
+                                Color(uiColor: UIColor.red),
+                                lineWidth: 3
+                            ) : nil)
+                        .frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
                         .onAppear {
                             StreamCoordinator.shared.playVideo(for: videoSource, quality: .auto)
                         }
@@ -46,8 +54,13 @@ struct ListView: View {
                                 id: \.self) { i in
                                     let index: Int = selectedSourceIndex <= i ? i + 1 : i
                                     if let gridVideoSource = videoSourceFrom(index: index),
-                                        let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
+                                       let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
                                         VideoRendererView(viewProvider: viewProvider)
+                                            .overlay(highlightedIndex == index ? Rectangle()
+                                                .stroke(
+                                                    Color(uiColor: UIColor.red),
+                                                    lineWidth: 3
+                                                ) : nil)
                                             .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
                                             .onTapGesture {
                                                 onSelectedSourceIndexChange(index)

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -4,22 +4,23 @@
 
 import SwiftUI
 import DolbyIORTSCore
+import DolbyIOUIKit
 
 struct ListView: View {
     private var viewModel: StreamViewModel
-    private var highlightedIndex: Int
-    private var selectedSourceIndex: Int
-    private var onSelectedSourceIndexChange: (Int) -> Void
-    private var onSelectedSourceClick: () -> Void
+    private var selectedAudioIndex: Int
+    private var selectedVideoIndex: Int
+    private var onSelectVideoSource: (Int) -> Void
+    private var onChangeOfViewMode: () -> Void
 
-    let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
+    let columns = [GridItem(.flexible(), spacing: Layout.spacing1x), GridItem(.flexible(), spacing: Layout.spacing1x)]
 
-    init(viewModel: StreamViewModel, highlightedIndex: Int, selectedSourceIndex: Int, onSelectedSourceIndexChange: @escaping (Int) -> Void, onSelectedSourceClick: @escaping () -> Void) {
+    init(viewModel: StreamViewModel, selectedAudioIndex: Int, selectedVideoIndex: Int, onSelectVideoSource: @escaping (Int) -> Void, onChangeOfViewMode: @escaping () -> Void) {
         self.viewModel = viewModel
-        self.highlightedIndex = highlightedIndex
-        self.selectedSourceIndex = selectedSourceIndex
-        self.onSelectedSourceIndexChange = onSelectedSourceIndexChange
-        self.onSelectedSourceClick = onSelectedSourceClick
+        self.selectedAudioIndex = selectedAudioIndex
+        self.selectedVideoIndex = selectedVideoIndex
+        self.onSelectVideoSource = onSelectVideoSource
+        self.onChangeOfViewMode = onChangeOfViewMode
     }
 
     var body: some View {
@@ -27,53 +28,55 @@ struct ListView: View {
             VStack {
                 let w = Float(geometry.size.width)
                 let h = Float(geometry.size.height) / 3
-                if let streamSource = videoSourceFrom(index: selectedSourceIndex),
+                if let streamSource = videoSourceFrom(index: selectedVideoIndex),
                    let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: streamSource) {
                     let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: CGSize(width: streamSource.width, height: streamSource.height), frameWidth: w, frameHeight: h)
-                    VideoRendererView(viewProvider: viewProvider)
-                        .overlay(highlightedIndex == selectedSourceIndex ? Rectangle()
-                            .stroke(
-                                Color(uiColor: UIColor.red),
-                                lineWidth: 3
-                            ) : nil)
-                        .frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
-                        .onAppear {
-                            StreamCoordinator.shared.playAudio(for: streamSource)
-                            StreamCoordinator.shared.playVideo(for: streamSource, quality: .auto)
-                        }
-                        .onDisappear {
-                            StreamCoordinator.shared.stopAudio(for: streamSource)
-                            StreamCoordinator.shared.stopVideo(for: streamSource)
-                        }
-                        .onTapGesture {
-                            onSelectedSourceClick()
-                        }
                     ScrollView {
-                        LazyVGrid(columns: columns) {
-                            ForEach(
-                                0..<(viewModel.sources.count - 1),
-                                id: \.self) { i in
-                                    let index: Int = selectedSourceIndex <= i ? i + 1 : i
-                                    if let gridVideoSource = videoSourceFrom(index: index),
-                                       let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
-                                        VideoRendererView(viewProvider: viewProvider)
-                                            .overlay(highlightedIndex == index ? Rectangle()
-                                                .stroke(
-                                                    Color(uiColor: UIColor.red),
-                                                    lineWidth: 3
-                                                ) : nil)
-                                            .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
-                                            .onTapGesture {
-                                                onSelectedSourceIndexChange(index)
-                                            }
-                                            .onAppear {
-                                                StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)
-                                            }
-                                            .onDisappear {
-                                                StreamCoordinator.shared.stopVideo(for: gridVideoSource)
-                                            }
+                        LazyVGrid(columns: columns, pinnedViews: [.sectionHeaders]) {
+                            Section(header: VideoRendererView(viewProvider: viewProvider)
+                                .overlay(selectedAudioIndex == selectedVideoIndex ? Rectangle()
+                                    .stroke(
+                                        Color(uiColor: UIColor.Primary.neonPurple400),
+                                        lineWidth: Layout.border2x
+                                    ) : nil)
+                                    .frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
+                                    .onAppear {
+                                        StreamCoordinator.shared.playAudio(for: streamSource)
+                                        StreamCoordinator.shared.playVideo(for: streamSource, quality: .auto)
                                     }
+                                .onDisappear {
+                                    StreamCoordinator.shared.stopAudio(for: streamSource)
+                                    StreamCoordinator.shared.stopVideo(for: streamSource)
                                 }
+                                .onTapGesture {
+                                    onChangeOfViewMode()
+                                }
+                            ) {
+                                ForEach(
+                                    0..<(viewModel.sources.count - 1),
+                                    id: \.self) { i in
+                                        let index: Int = selectedVideoIndex <= i ? i + 1 : i
+                                        if let gridVideoSource = videoSourceFrom(index: index),
+                                           let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
+                                            VideoRendererView(viewProvider: viewProvider)
+                                                .overlay(selectedAudioIndex == index ? Rectangle()
+                                                    .stroke(
+                                                        Color(uiColor: UIColor.Primary.neonPurple300),
+                                                        lineWidth: Layout.border2x
+                                                    ) : nil)
+                                                .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
+                                                .onTapGesture {
+                                                    onSelectVideoSource(index)
+                                                }
+                                                .onAppear {
+                                                    StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)
+                                                }
+                                                .onDisappear {
+                                                    StreamCoordinator.shared.stopVideo(for: gridVideoSource)
+                                                }
+                                        }
+                                    }
+                            }
                         }
                     }
                 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -38,12 +38,13 @@ struct ListView: View {
                     ScrollView {
                         LazyVGrid(columns: columns) {
                             ForEach(
-                                0..<viewModel.sources.count,
-                                id: \.self) { index in
+                                0..<viewModel.sources.count - 1,
+                                id: \.self) { i in
+                                    let index: Int = highlighted <= i ? i + 1 : i
                                     if let gridVideoSource = videoSourceFrom(index: index) {
                                         if let view = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource)?.playbackView {
                                             VideoRendererView(uiView: view)
-                                                .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2), alignment: Alignment.trailing)
+                                                .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
                                                 .onTapGesture {
                                                     onHighlighted(index)
                                                 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -2,7 +2,6 @@
 //  ListView.swift
 //
 
-import Foundation
 import SwiftUI
 import DolbyIORTSCore
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -8,17 +8,17 @@ import DolbyIORTSCore
 
 struct ListView: View {
     private var viewModel: StreamViewModel
-    private var highlighted: Int
-    private var onHighlightedChange: (Int) -> Void
-    private var onHighlightedClick: () -> Void
+    private var selectedSourceIndex: Int
+    private var onSelectedSourceIndexChange: (Int) -> Void
+    private var onSelectedSourceClick: () -> Void
 
     let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
 
-    init(viewModel: StreamViewModel, highlighted: Int, onHighlightedChange: @escaping (Int) -> Void, onHighlightedClick: @escaping () -> Void) {
+    init(viewModel: StreamViewModel, selectedSourceIndex: Int, onSelectedSourceIndexChange: @escaping (Int) -> Void, onSelectedSourceClick: @escaping () -> Void) {
         self.viewModel = viewModel
-        self.highlighted = highlighted
-        self.onHighlightedChange = onHighlightedChange
-        self.onHighlightedClick = onHighlightedClick
+        self.selectedSourceIndex = selectedSourceIndex
+        self.onSelectedSourceIndexChange = onSelectedSourceIndexChange
+        self.onSelectedSourceClick = onSelectedSourceClick
     }
 
     var body: some View {
@@ -26,7 +26,7 @@ struct ListView: View {
             VStack {
                 let w = Float(geometry.size.width)
                 let h = Float(geometry.size.height) / 3
-                if let videoSource = videoSourceFrom(index: highlighted),
+                if let videoSource = videoSourceFrom(index: selectedSourceIndex),
                     let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource) {
                     let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: videoSource.width, height: videoSource.height), frameWidth: w, frameHeight: h)
                     VideoRendererView(viewProvider: viewProvider).frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
@@ -37,20 +37,20 @@ struct ListView: View {
                             StreamCoordinator.shared.stopVideo(for: videoSource)
                         }
                         .onTapGesture {
-                            onHighlightedClick()
+                            onSelectedSourceClick()
                         }
                     ScrollView {
                         LazyVGrid(columns: columns) {
                             ForEach(
                                 0..<(viewModel.sources.count - 1),
                                 id: \.self) { i in
-                                    let index: Int = highlighted <= i ? i + 1 : i
+                                    let index: Int = selectedSourceIndex <= i ? i + 1 : i
                                     if let gridVideoSource = videoSourceFrom(index: index),
                                         let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
                                         VideoRendererView(viewProvider: viewProvider)
                                             .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
                                             .onTapGesture {
-                                                onHighlightedChange(index)
+                                                onSelectedSourceIndexChange(index)
                                             }
                                             .onAppear {
                                                 StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -28,9 +28,9 @@ struct ListView: View {
             VStack {
                 let w = Float(geometry.size.width)
                 let h = Float(geometry.size.height) / 3
-                if let videoSource = videoSourceFrom(index: selectedSourceIndex),
-                   let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource) {
-                    let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: videoSource.width, height: videoSource.height), frameWidth: w, frameHeight: h)
+                if let streamSource = videoSourceFrom(index: selectedSourceIndex),
+                   let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: streamSource) {
+                    let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: streamSource.width, height: streamSource.height), frameWidth: w, frameHeight: h)
                     VideoRendererView(viewProvider: viewProvider)
                         .overlay(highlightedIndex == selectedSourceIndex ? Rectangle()
                             .stroke(
@@ -39,10 +39,12 @@ struct ListView: View {
                             ) : nil)
                         .frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
                         .onAppear {
-                            StreamCoordinator.shared.playVideo(for: videoSource, quality: .auto)
+                            StreamCoordinator.shared.playAudio(for: streamSource)
+                            StreamCoordinator.shared.playVideo(for: streamSource, quality: .auto)
                         }
                         .onDisappear {
-                            StreamCoordinator.shared.stopVideo(for: videoSource)
+                            StreamCoordinator.shared.stopAudio(for: streamSource)
+                            StreamCoordinator.shared.stopVideo(for: streamSource)
                         }
                         .onTapGesture {
                             onSelectedSourceClick()
@@ -69,7 +71,7 @@ struct ListView: View {
                                                 StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)
                                             }
                                             .onDisappear {
-                                                StreamCoordinator.shared.stopVideo(for: videoSource)
+                                                StreamCoordinator.shared.stopVideo(for: gridVideoSource)
                                             }
                                     }
                                 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -29,7 +29,7 @@ struct ListView: View {
                 let h = Float(geometry.size.height) / 3
                 if let streamSource = videoSourceFrom(index: selectedSourceIndex),
                    let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: streamSource) {
-                    let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: streamSource.width, height: streamSource.height), frameWidth: w, frameHeight: h)
+                    let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: CGSize(width: streamSource.width, height: streamSource.height), frameWidth: w, frameHeight: h)
                     VideoRendererView(viewProvider: viewProvider)
                         .overlay(highlightedIndex == selectedSourceIndex ? Rectangle()
                             .stroke(

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -1,0 +1,56 @@
+//
+//  ListView.swift
+//
+
+import Foundation
+import SwiftUI
+import DolbyIORTSCore
+
+struct ListView: View {
+    private var viewModel: StreamViewModel
+    private var highlighted: Int
+    private var onHighlighted: (Int) -> Void
+
+    let columns = [GridItem(.flexible()), GridItem(.flexible())]
+
+    init(viewModel: StreamViewModel, highlighted: Int, onHighlighted: @escaping (Int) -> Void) {
+        self.viewModel = viewModel
+        self.highlighted = highlighted
+        self.onHighlighted = onHighlighted
+    }
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack {
+                let w = Float(geometry.size.width)
+                let h = Float(geometry.size.height) / 3
+                if let videoSource = videoSourceFrom(index: highlighted) {
+                    let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: videoSource.width, height: videoSource.height), frameWidth: w, frameHeight: h)
+                    if let view = viewModel.streamCoordinator.subSourceViewProvider(for: videoSource)?.playbackView {
+                        VideoRendererView(uiView: view).frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height)).background(Color.red)
+                    }
+                    ScrollView {
+                        LazyVGrid(columns: columns) {
+                            ForEach(
+                                0..<viewModel.sources.count,
+                                id: \.self) { index in
+                                    if let gridVideoSource = videoSourceFrom(index: index) {
+                                        if let view = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource)?.playbackView {
+                                            VideoRendererView(uiView: view).frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
+                                                .onTapGesture {
+                                                    onHighlighted(index)
+                                                }.background(Color.blue)
+                                        }
+                                    }
+                                }
+                        }
+                    }.padding(.horizontal)
+                }
+            }
+        }
+    }
+
+    private func videoSourceFrom(index: Int) -> StreamSource? {
+        return viewModel.sources.count > index ? viewModel.sources[index] : nil
+    }
+}

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -9,14 +9,16 @@ import DolbyIORTSCore
 struct ListView: View {
     private var viewModel: StreamViewModel
     private var highlighted: Int
-    private var onHighlighted: (Int) -> Void
+    private var onHighlightedChange: (Int) -> Void
+    private var onHighlightedClick: () -> Void
 
     let columns = [GridItem(.flexible(), spacing: 10), GridItem(.flexible(), spacing: 10)]
 
-    init(viewModel: StreamViewModel, highlighted: Int, onHighlighted: @escaping (Int) -> Void) {
+    init(viewModel: StreamViewModel, highlighted: Int, onHighlightedChange: @escaping (Int) -> Void, onHighlightedClick: @escaping () -> Void) {
         self.viewModel = viewModel
         self.highlighted = highlighted
-        self.onHighlighted = onHighlighted
+        self.onHighlightedChange = onHighlightedChange
+        self.onHighlightedClick = onHighlightedClick
     }
 
     var body: some View {
@@ -34,6 +36,9 @@ struct ListView: View {
                         .onDisappear {
                             StreamCoordinator.shared.stopVideo(for: videoSource)
                         }
+                        .onTapGesture {
+                            onHighlightedClick()
+                        }
                     ScrollView {
                         LazyVGrid(columns: columns) {
                             ForEach(
@@ -45,7 +50,7 @@ struct ListView: View {
                                         VideoRendererView(viewProvider: viewProvider)
                                             .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
                                             .onTapGesture {
-                                                onHighlighted(index)
+                                                onHighlightedChange(index)
                                             }
                                             .onAppear {
                                                 StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/ListView.swift
@@ -24,37 +24,35 @@ struct ListView: View {
             VStack {
                 let w = Float(geometry.size.width)
                 let h = Float(geometry.size.height) / 3
-                if let videoSource = videoSourceFrom(index: highlighted) {
+                if let videoSource = videoSourceFrom(index: highlighted),
+                    let viewProvider = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource) {
                     let videoSize = viewModel.calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions(width: videoSource.width, height: videoSource.height), frameWidth: w, frameHeight: h)
-                    if let view = viewModel.streamCoordinator.mainSourceViewProvider(for: videoSource)?.playbackView {
-                        VideoRendererView(uiView: view).frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
-                            .onAppear {
-                                StreamCoordinator.shared.playVideo(for: videoSource, quality: .auto)
-                            }
-                            .onDisappear {
-                                StreamCoordinator.shared.stopVideo(for: videoSource)
-                            }
-                    }
+                    VideoRendererView(viewProvider: viewProvider).frame(width: CGFloat(videoSize.width), height: CGFloat(videoSize.height))
+                        .onAppear {
+                            StreamCoordinator.shared.playVideo(for: videoSource, quality: .auto)
+                        }
+                        .onDisappear {
+                            StreamCoordinator.shared.stopVideo(for: videoSource)
+                        }
                     ScrollView {
                         LazyVGrid(columns: columns) {
                             ForEach(
-                                0..<viewModel.sources.count - 1,
+                                0..<(viewModel.sources.count - 1),
                                 id: \.self) { i in
                                     let index: Int = highlighted <= i ? i + 1 : i
-                                    if let gridVideoSource = videoSourceFrom(index: index) {
-                                        if let view = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource)?.playbackView {
-                                            VideoRendererView(uiView: view)
-                                                .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
-                                                .onTapGesture {
-                                                    onHighlighted(index)
-                                                }
-                                                .onAppear {
-                                                    StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)
-                                                }
-                                                .onDisappear {
-                                                    StreamCoordinator.shared.stopVideo(for: videoSource)
-                                                }
-                                        }
+                                    if let gridVideoSource = videoSourceFrom(index: index),
+                                        let viewProvider = viewModel.streamCoordinator.subSourceViewProvider(for: gridVideoSource) {
+                                        VideoRendererView(viewProvider: viewProvider)
+                                            .frame(width: CGFloat(videoSize.width / 2), height: CGFloat(videoSize.height / 2))
+                                            .onTapGesture {
+                                                onHighlighted(index)
+                                            }
+                                            .onAppear {
+                                                StreamCoordinator.shared.playVideo(for: gridVideoSource, quality: .auto)
+                                            }
+                                            .onDisappear {
+                                                StreamCoordinator.shared.stopVideo(for: videoSource)
+                                            }
                                     }
                                 }
                         }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -13,7 +13,7 @@ public struct StreamingView: View {
     public var body: some View {
         switch viewModel.mode {
         case .list, .single:
-            ListView(viewModel: viewModel, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
+            ListView(viewModel: viewModel, highlightedIndex: viewModel.highlightedIndex, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
         }
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -8,12 +8,13 @@ import DolbyIORTSCore
 public struct StreamingView: View {
     @StateObject private var viewModel: StreamViewModel = .init()
 
-    @State private var highlighted: Int = 0
-
     public init() {}
 
     public var body: some View {
-        ListView(viewModel: viewModel, highlighted: highlighted, onHighlighted: { index in highlighted = index })
+        switch viewModel.mode {
+        case .list, .single:
+            ListView(viewModel: viewModel, highlighted: viewModel.highlighted, onHighlightedChange: { index in viewModel.highlightedChange(index: index) }, onHighlightedClick: { viewModel.highlightedClick() })
+        }
     }
 }
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -13,7 +13,7 @@ public struct StreamingView: View {
     public var body: some View {
         switch viewModel.mode {
         case .list, .single:
-            ListView(viewModel: viewModel, highlightedIndex: viewModel.highlightedIndex, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
+            ListView(viewModel: viewModel, highlightedIndex: viewModel.audioSelectedIndex, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
         }
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -11,7 +11,7 @@ public struct StreamingView: View {
     public init() {}
 
     public var body: some View {
-        EmptyView()
+        ListView(viewModel: viewModel, highlighted: 0, onHighlighted: {_ in })
     }
 }
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -13,7 +13,7 @@ public struct StreamingView: View {
     public var body: some View {
         switch viewModel.mode {
         case .list, .single:
-            ListView(viewModel: viewModel, highlighted: viewModel.highlighted, onHighlightedChange: { index in viewModel.highlightedChange(index: index) }, onHighlightedClick: { viewModel.highlightedClick() })
+            ListView(viewModel: viewModel, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
         }
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -8,10 +8,12 @@ import DolbyIORTSCore
 public struct StreamingView: View {
     @StateObject private var viewModel: StreamViewModel = .init()
 
+    @State private var highlighted: Int = 0
+
     public init() {}
 
     public var body: some View {
-        ListView(viewModel: viewModel, highlighted: 0, onHighlighted: {_ in })
+        ListView(viewModel: viewModel, highlighted: highlighted, onHighlighted: { index in highlighted = index })
     }
 }
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/StreamingView.swift
@@ -13,7 +13,12 @@ public struct StreamingView: View {
     public var body: some View {
         switch viewModel.mode {
         case .list, .single:
-            ListView(viewModel: viewModel, highlightedIndex: viewModel.audioSelectedIndex, selectedSourceIndex: viewModel.selectedSourceIndex, onSelectedSourceIndexChange: { index in viewModel.selectedSourceIndexChange(index: index) }, onSelectedSourceClick: { viewModel.selectedSourceClick() })
+            ListView(
+                viewModel: viewModel,
+                selectedAudioIndex: viewModel.audioSelectedIndex,
+                selectedVideoIndex: viewModel.videoSelectedIndex,
+                onSelectVideoSource: { index in viewModel.videoSelectedChange(index: index) },
+                onChangeOfViewMode: { viewModel.selectedSourceClick() })
         }
     }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
@@ -2,22 +2,59 @@
 //  VideoRenderer.swift
 //
 
-import AVKit
+import DolbyIORTSCore
 import Foundation
-import MillicastSDK
 import SwiftUI
 
 struct VideoRendererView: UIViewRepresentable {
-    private let uiView: UIView
+    private let viewProvider: SourceViewProviding
 
-    init(uiView: UIView) {
-        self.uiView = uiView
+    init(viewProvider: SourceViewProviding) {
+        self.viewProvider = viewProvider
     }
 
     func makeUIView(context: Context) -> UIView {
-        uiView.contentMode = .scaleAspectFit
-        return uiView
+        let containerView = ContainerView<UIView>()
+        containerView.updateChildView(viewProvider.playbackView)
+
+        return containerView
     }
 
-    func updateUIView(_ uiView: UIView, context: Context) {}
+    func updateUIView(_ uiView: UIView, context: Context) {
+        guard let containerView = uiView as? ContainerView<UIView> else {
+            return
+        }
+        containerView.updateChildView(viewProvider.playbackView)
+    }
+}
+
+private final class ContainerView<ChildView: UIView>: UIView {
+
+    private var childView: ChildView?
+
+    init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func updateChildView(_ view: ChildView) {
+        childView?.removeFromSuperview()
+
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(view)
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: view.topAnchor),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            view.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        childView = view
+
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
@@ -1,0 +1,23 @@
+//
+//  VideoRenderer.swift
+//
+
+import AVKit
+import Foundation
+import MillicastSDK
+import SwiftUI
+
+struct VideoRendererView: UIViewRepresentable {
+    private let uiView: UIView
+
+    init(uiView: UIView) {
+        self.uiView = uiView
+    }
+
+    func makeUIView(context: Context) -> UIView {
+        uiView.contentMode = .scaleAspectFit
+        return uiView
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
+}

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
@@ -32,7 +32,7 @@ private final class ContainerView<ChildView: UIView>: UIView {
     private var childView: ChildView?
 
     init() {
-        super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        super.init(frame: CGRect(x: 0, y: 0, width: .zero, height: .zero))
     }
 
     required init?(coder: NSCoder) {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Components/VideoRendererView.swift
@@ -1,9 +1,8 @@
 //
-//  VideoRenderer.swift
+//  VideoRendererView.swift
 //
 
 import DolbyIORTSCore
-import Foundation
 import SwiftUI
 
 struct VideoRendererView: UIViewRepresentable {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -12,7 +12,7 @@ final class StreamViewModel: ObservableObject {
 
     private var subscriptions: [AnyCancellable] = []
     @Published private(set) var sources: [StreamSource] = []
-    @Published private(set) var highlighted: Int = 0
+    @Published private(set) var selectedSourceIndex: Int = 0
     @Published private(set) var mode: StreamViewMode = .list
 
     init(streamCoordinator: StreamCoordinator = .shared) {
@@ -50,11 +50,11 @@ final class StreamViewModel: ObservableObject {
         return StreamSource.Dimensions(width: scaledWidth, height: scaledHeight)
     }
 
-    func highlightedChange(index: Int) {
-        highlighted = index
+    func selectedSourceIndexChange(index: Int) {
+        selectedSourceIndex = index
     }
 
-    func highlightedClick() {
+    func selectedSourceClick() {
         switch mode {
         case .list:
             mode = .single

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -12,7 +12,7 @@ final class StreamViewModel: ObservableObject {
 
     private var subscriptions: [AnyCancellable] = []
     @Published private(set) var sources: [StreamSource] = []
-    @Published private(set) var highlightedIndex: Int = 0
+    @Published private(set) var audioSelectedIndex: Int = 0
     @Published private(set) var selectedSourceIndex: Int = 0
     @Published private(set) var mode: StreamViewMode = .list
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -12,6 +12,7 @@ final class StreamViewModel: ObservableObject {
 
     private var subscriptions: [AnyCancellable] = []
     @Published private(set) var sources: [StreamSource] = []
+    @Published private(set) var highlightedIndex: Int = 0
     @Published private(set) var selectedSourceIndex: Int = 0
     @Published private(set) var mode: StreamViewMode = .list
 

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -33,4 +33,51 @@ final class StreamViewModel: ObservableObject {
             }
             .store(in: &subscriptions)
     }
+
+    func calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions, frameWidth: Float, frameHeight: Float) -> StreamSource.Dimensions {
+        let ratio = calculateAspectRatio(
+            crop: false,
+            frameWidth: frameWidth,
+            frameHeight: frameHeight,
+            videoWidth: videoSourceDimensions.width,
+            videoHeight: videoSourceDimensions.height
+        )
+
+        let scaledWidth = videoSourceDimensions.width * ratio
+        let scaledHeight = videoSourceDimensions.height * ratio
+        return StreamSource.Dimensions(width: scaledWidth, height: scaledHeight)
+    }
+
+    private func calculateAspectRatio(crop: Bool, frameWidth: Float, frameHeight: Float, videoWidth: Float, videoHeight: Float) -> Float {
+        guard videoWidth > 0, videoHeight > 0 else {
+            return 0.0
+        }
+
+        var ratio: Float = 0
+        var widthHeading: Bool = true
+        if frameWidth >= videoWidth && frameHeight >= videoHeight {
+            if (frameWidth / videoWidth) < (frameHeight / videoHeight) {
+                widthHeading = !crop
+            } else {
+                widthHeading = crop
+            }
+        } else if frameWidth >= videoWidth {
+            widthHeading = crop
+        } else if frameHeight >= videoHeight {
+            widthHeading = !crop
+        } else {
+            if (frameWidth / videoWidth) > (frameHeight / videoHeight) {
+                widthHeading = crop
+            } else {
+                widthHeading = !crop
+            }
+        }
+        if widthHeading {
+            ratio = frameWidth / videoWidth
+        } else {
+            ratio = frameHeight / videoHeight
+        }
+        return ratio
+    }
+
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -12,6 +12,8 @@ final class StreamViewModel: ObservableObject {
 
     private var subscriptions: [AnyCancellable] = []
     @Published private(set) var sources: [StreamSource] = []
+    @Published private(set) var highlighted: Int = 0
+    @Published private(set) var mode: StreamViewMode = .list
 
     init(streamCoordinator: StreamCoordinator = .shared) {
         self.streamCoordinator = streamCoordinator
@@ -48,6 +50,19 @@ final class StreamViewModel: ObservableObject {
         return StreamSource.Dimensions(width: scaledWidth, height: scaledHeight)
     }
 
+    func highlightedChange(index: Int) {
+        highlighted = index
+    }
+
+    func highlightedClick() {
+        switch mode {
+        case .list:
+            mode = .single
+        case .single:
+            mode = .list
+        }
+    }
+
     private func calculateAspectRatio(crop: Bool, frameWidth: Float, frameHeight: Float, videoWidth: Float, videoHeight: Float) -> Float {
         guard videoWidth > 0, videoHeight > 0 else {
             return 0.0
@@ -79,5 +94,8 @@ final class StreamViewModel: ObservableObject {
         }
         return ratio
     }
+}
 
+enum StreamViewMode {
+    case single, list
 }

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -13,7 +13,7 @@ final class StreamViewModel: ObservableObject {
     private var subscriptions: [AnyCancellable] = []
     @Published private(set) var sources: [StreamSource] = []
     @Published private(set) var audioSelectedIndex: Int = 0
-    @Published private(set) var selectedSourceIndex: Int = 0
+    @Published private(set) var videoSelectedIndex: Int = 0
     @Published private(set) var mode: StreamViewMode = .list
 
     init(streamCoordinator: StreamCoordinator = .shared) {
@@ -51,8 +51,8 @@ final class StreamViewModel: ObservableObject {
         return CGSize(width: CGFloat(scaledWidth), height: CGFloat(scaledHeight))
     }
 
-    func selectedSourceIndexChange(index: Int) {
-        selectedSourceIndex = index
+    func videoSelectedChange(index: Int) {
+        videoSelectedIndex = index
     }
 
     func selectedSourceClick() {

--- a/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/LocalPackages/DolbyIORTSUIKit/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -37,18 +37,18 @@ final class StreamViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
-    func calculateVideoSize(videoSourceDimensions: StreamSource.Dimensions, frameWidth: Float, frameHeight: Float) -> StreamSource.Dimensions {
+    func calculateVideoSize(videoSourceDimensions: CGSize, frameWidth: Float, frameHeight: Float) -> CGSize {
         let ratio = calculateAspectRatio(
             crop: false,
             frameWidth: frameWidth,
             frameHeight: frameHeight,
-            videoWidth: videoSourceDimensions.width,
-            videoHeight: videoSourceDimensions.height
+            videoWidth: Float(videoSourceDimensions.width),
+            videoHeight: Float(videoSourceDimensions.height)
         )
 
-        let scaledWidth = videoSourceDimensions.width * ratio
-        let scaledHeight = videoSourceDimensions.height * ratio
-        return StreamSource.Dimensions(width: scaledWidth, height: scaledHeight)
+        let scaledWidth = Float(videoSourceDimensions.width) * ratio
+        let scaledHeight = Float(videoSourceDimensions.height) * ratio
+        return CGSize(width: CGFloat(scaledWidth), height: CGFloat(scaledHeight))
     }
 
     func selectedSourceIndexChange(index: Int) {


### PR DESCRIPTION
- One large view + The rest are listed in small video views
- The small video tiles are listed at the bottom, in 2 columns
- Swiped vertically to show more views if there are more video views
- Tapping one of the small videos will transform it into the large video view
- The video title shall be highlighted if the corresponding audio is selected

### Notes
- Component configurations will go in a separate PR