### PR TITLE
Bugfix/reset state on unsubscribe

### DIFF
--- a/rts-viewer-tvos/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Store/RTSDataStore.swift
+++ b/rts-viewer-tvos/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Store/RTSDataStore.swift
@@ -262,7 +262,7 @@ extension RTSDataStore {
         self.layersObservation = nil
         self.statsObservation = nil
     }
-    
+
     func resetState() {
         streamDetail = nil
         subscriptionManager = nil

--- a/rts-viewer-tvos/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Store/RTSDataStore.swift
+++ b/rts-viewer-tvos/LocalPackages/RTSComponentKit/Sources/RTSComponentKit/Store/RTSDataStore.swift
@@ -85,12 +85,13 @@ open class RTSDataStore: ObservableObject {
     }
 
     open func stopSubscribe() async throws -> Bool {
-        defer { deregisterToSubscriberStreams() }
+        defer {
+            deregisterToSubscriberStreams()
+            resetState()
+        }
         guard let subscriptionManager else { return false }
         let success = try await subscriptionManager.stopSubscribe()
 
-        self.streamDetail = nil
-        self.subscriptionManager = nil
         return success
     }
 
@@ -260,6 +261,16 @@ extension RTSDataStore {
         self.activityObservation = nil
         self.layersObservation = nil
         self.statsObservation = nil
+    }
+    
+    func resetState() {
+        streamDetail = nil
+        subscriptionManager = nil
+        state = .disconnected
+        detailedVideoQualityList = []
+        selectedDetailedVideoQuality = .auto
+        mainSourceId = nil
+        mainVideoTrack = nil
     }
 }
 

--- a/rts-viewer-tvos/RTSViewer/Common/StreamingScreen/ViewModels/DisplayStreamViewModel.swift
+++ b/rts-viewer-tvos/RTSViewer/Common/StreamingScreen/ViewModels/DisplayStreamViewModel.swift
@@ -49,6 +49,7 @@ final class DisplayStreamViewModel: ObservableObject {
 
     func updateLiveIndicator(_ enabled: Bool) {
         isLiveIndicatorEnabled = enabled
+        persistentSettings.liveIndicatorEnabled = enabled
     }
 
     // swiftlint:disable function_body_length


### PR DESCRIPTION
Description:

1. Reset state on unsubscribe - fixes stale layer information shown from previous subscription
2. Set Live indictor state globally to be used across session