### PR TITLE
Bugfix/interactive player crash n accessibility ids

### DIFF
--- a/interactive-player/Interactive Viewer/Managers/VideoTracksManager.swift
+++ b/interactive-player/Interactive Viewer/Managers/VideoTracksManager.swift
@@ -40,16 +40,15 @@ final actor VideoTracksManager {
     private var sourceToSimulcastLayersMapping: [SourceID: [MCRTSRemoteTrackLayer]] = [:]
     private var sourceToSelectedVideoQualityAndLayerMapping: [SourceID: VideoQualityAndLayerPair] = [:] {
         didSet {
-            let sourceToVideoQuality = self.sourceToSelectedVideoQualityAndLayerMapping
+            let sourceToVideoQuality = sourceToSelectedVideoQualityAndLayerMapping
                 .mapValues {
                     $0.videoQuality
                 }
-            self.videoQualitySubject.send(sourceToVideoQuality)
+            videoQualitySubject.send(sourceToVideoQuality)
         }
     }
 
     private var layerEventsObservationDictionary: [SourceID: Task<Void, Never>] = [:]
-    private var sourceToTasks: [SourceID: SerialTasks] = [:]
     private let videoQualitySubject: CurrentValueSubject<[SourceID: VideoQuality], Never> = CurrentValueSubject([:])
     let rendererRegistry: RendererRegistry
     lazy var selectedVideoQualityPublisher = videoQualitySubject.eraseToAnyPublisher()
@@ -81,12 +80,11 @@ final actor VideoTracksManager {
     }
 
     func reset() {
-        self.sourceToTasks.removeAll()
-        self.layerEventsObservationDictionary.removeAll()
-        self.sourceToActiveViewsMapping.removeAll()
-        self.viewToRequestedVideoQualityMapping.removeAll()
-        self.sourceToSimulcastLayersMapping.removeAll()
-        self.sourceToSelectedVideoQualityAndLayerMapping.removeAll()
+        layerEventsObservationDictionary.removeAll()
+        sourceToActiveViewsMapping.removeAll()
+        viewToRequestedVideoQualityMapping.removeAll()
+        sourceToSimulcastLayersMapping.removeAll()
+        sourceToSelectedVideoQualityAndLayerMapping.removeAll()
     }
 
     func enableTrack(for source: StreamSource, with preferredVideoQuality: VideoQuality, on view: ViewID) async {
@@ -94,19 +92,19 @@ final actor VideoTracksManager {
         Self.logger.debug("♼ Request to enable video track for source \(sourceId) with preferredVideoQuality \(preferredVideoQuality.displayText) from view \(view.description)")
 
         // If the view has already requested the same video quality before? if yes, exit
-        guard self.viewToRequestedVideoQualityMapping[view] != preferredVideoQuality else {
+        guard viewToRequestedVideoQualityMapping[view] != preferredVideoQuality else {
             Self.logger.debug("♼ Exiting - View already presented for source \(sourceId) with preferredVideoQuality \(preferredVideoQuality.displayText)")
             return
         }
 
-        let activeViewsForSource = self.sourceToActiveViewsMapping[sourceId] ?? []
+        let activeViewsForSource = sourceToActiveViewsMapping[sourceId] ?? []
         // Calculate the video quality to project from the requested list
         // Note: Only one layer can be selected for a source at a given time
         var videoQualitiesRequestedForSource = activeViewsForSource
-            .compactMap { self.viewToRequestedVideoQualityMapping[$0] }
+            .compactMap { viewToRequestedVideoQualityMapping[$0] }
         videoQualitiesRequestedForSource.append(preferredVideoQuality)
         let bestVideoQualityFromTheList = videoQualitiesRequestedForSource.bestVideoQualityFromTheRequestedList
-        let simulcastLayers = self.sourceToSimulcastLayersMapping[sourceId]
+        let simulcastLayers = sourceToSimulcastLayersMapping[sourceId]
         let layerToSelect = simulcastLayers.map { $0.matching(quality: bestVideoQualityFromTheList) } ?? nil
         Self.logger.debug("♼ Source \(sourceId) has \(simulcastLayers?.count ?? 0) simulcast layers")
 
@@ -115,29 +113,29 @@ final actor VideoTracksManager {
 
         Self.logger.debug("♼ Add active view \(view.description) for source \(sourceId)")
         // Update view's requested video quality
-        self.viewToRequestedVideoQualityMapping[view] = preferredVideoQuality
+        viewToRequestedVideoQualityMapping[view] = preferredVideoQuality
 
         // Add new view to the list of active views for that source
         if var views = sourceToActiveViewsMapping[sourceId] {
             views.append(view)
-            self.sourceToActiveViewsMapping[source.sourceId] = views
+            sourceToActiveViewsMapping[source.sourceId] = views
         } else {
-            self.sourceToActiveViewsMapping[source.sourceId] = [view]
+            sourceToActiveViewsMapping[source.sourceId] = [view]
         }
 
         do {
             if let layerToSelect {
                 Self.logger.debug("♼ Simulcast layer - \(layerToSelect) for source \(sourceId)")
                 Self.logger.debug("♼ Selecting videoquality \(videoQualityToSelect.displayText) for source \(sourceId) on view \(view)")
-                self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
 
-                try await self.queueEnableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
+                try await enableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
             } else {
                 Self.logger.debug("♼ No simulcast layer for source \(sourceId) matching \(bestVideoQualityFromTheList.displayText)")
                 Self.logger.debug("♼ Selecting videoquality 'Auto' for source \(sourceId) on view \(view)")
-                self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
 
-                try await self.queueEnableTrack(for: source)
+                try await enableTrack(for: source)
             }
         } catch {
             Self.logger.debug("♼🛑 Enabling video track threw error \(error.localizedDescription)")
@@ -147,23 +145,26 @@ final actor VideoTracksManager {
     func disableTrack(for source: StreamSource, on view: ViewID) async {
         let sourceId = source.sourceId
         Self.logger.debug("♼ Request to disable video track for source \(sourceId) on view \(view.description)")
-        Self.logger.debug("♼ Remove view \(view.description) for source \(sourceId)")
         // Remove view from the list of active views for that source
-        if var activeViews = sourceToActiveViewsMapping[sourceId],
-           activeViews.contains(where: { $0 == view }) {
-            activeViews.removeAll(where: { $0 == view })
-            self.sourceToActiveViewsMapping[source.sourceId] = !activeViews.isEmpty ? activeViews : nil
+        guard var activeViews = sourceToActiveViewsMapping[sourceId],
+            activeViews.contains(where: { $0 == view })
+        else {
+            Self.logger.debug("♼ \(view.description) is not in the list of active views, returning")
+            return
         }
+        Self.logger.debug("♼ Remove view \(view.description) for source \(sourceId)")
+        activeViews.removeAll(where: { $0 == view })
+        sourceToActiveViewsMapping[source.sourceId] = !activeViews.isEmpty ? activeViews : nil
 
         // Remove view from View to requested video quality mapping
-        self.viewToRequestedVideoQualityMapping[view] = nil
+        viewToRequestedVideoQualityMapping[view] = nil
 
         if let activeViews = sourceToActiveViewsMapping[sourceId] {
             // Calculate the video quality to project from the requested list
             // Note: Only one projection can exist for a source at a given time
-            let videoQualitiesRequestedForSource = activeViews.compactMap { self.viewToRequestedVideoQualityMapping[$0] }
+            let videoQualitiesRequestedForSource = activeViews.compactMap { viewToRequestedVideoQualityMapping[$0] }
             let bestVideoQualityFromRequested = videoQualitiesRequestedForSource.bestVideoQualityFromTheRequestedList
-            let simulcastLayers = self.sourceToSimulcastLayersMapping[sourceId]
+            let simulcastLayers = sourceToSimulcastLayersMapping[sourceId]
             let layerToSelect = simulcastLayers.map { $0.matching(quality: bestVideoQualityFromRequested) } ?? nil
 
             let selectedVideoQuality: VideoQuality = layerToSelect == nil ? .auto : bestVideoQualityFromRequested
@@ -173,13 +174,13 @@ final actor VideoTracksManager {
                 if let layerToSelect {
                     Self.logger.debug("♼ Has simulcast layer - \(layerToSelect) for source \(sourceId)")
                     Self.logger.debug("♼ Selecting videoquality \(selectedVideoQuality.displayText) for source \(sourceId); active view \(activeViews)")
-                    self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
-                    try await self.queueEnableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
+                    sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                    try await enableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
                 } else {
                     Self.logger.debug("♼ No simulcast layer for source \(sourceId) matching \(bestVideoQualityFromRequested.displayText)")
                     Self.logger.debug("♼ Selecting videoquality 'Auto' for source \(sourceId); active view \(activeViews)")
-                    self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
-                    try await self.queueEnableTrack(for: source)
+                    sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                    try await enableTrack(for: source)
                 }
             } catch {
                 Self.logger.debug("♼🛑 Enabling video track threw error \(error.localizedDescription)")
@@ -189,45 +190,35 @@ final actor VideoTracksManager {
                 Self.logger.debug("♼ Disable video track for source \(sourceId) as there are no active views")
 
                 // Remove selected Video quality for source
-                self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = nil
+                sourceToSelectedVideoQualityAndLayerMapping[sourceId] = nil
 
                 removeAllStoredData(for: source)
 
-                try await self.queueDisableTrack(for: source)
+                try await disableTrack(for: source)
             } catch {
                 Self.logger.debug("♼🛑 Disabling video track threw error \(error.localizedDescription)")
             }
         }
     }
 
-    func queueEnableTrack(for source: StreamSource, layer: MCRTSRemoteVideoTrackLayer? = nil) async throws {
-        if self.sourceToTasks[source.sourceId] == nil {
-            self.sourceToTasks[source.sourceId] = SerialTasks()
+    func enableTrack(for source: StreamSource, layer: MCRTSRemoteVideoTrackLayer? = nil) async throws {
+        let renderer = rendererRegistry.sampleBufferRenderer(for: source).underlyingRenderer
+        guard source.videoTrack.isActive else { return }
+        Self.logger.debug("♼ Queue: Enabling track for source \(source.sourceId) on renderer \(ObjectIdentifier(renderer).debugDescription)")
+        guard !Task.isCancelled, source.videoTrack.isActive else { return }
+        if let layer {
+            try await source.videoTrack.enable(renderer: renderer, layer: layer)
+        } else {
+            try await source.videoTrack.enable(renderer: renderer)
         }
-
-        let renderer = self.rendererRegistry.sampleBufferRenderer(for: source).underlyingRenderer
-        guard let serialTasks = sourceToTasks[source.sourceId],
-              source.videoTrack.isActive else { return }
-        try await serialTasks.enqueue {
-            Self.logger.debug("♼ Queue: Enabling track for source \(source.sourceId) on renderer \(ObjectIdentifier(renderer).debugDescription)")
-            guard !Task.isCancelled, source.videoTrack.isActive else { return }
-            if let layer {
-                try await source.videoTrack.enable(renderer: renderer, layer: layer)
-            } else {
-                try await source.videoTrack.enable(renderer: renderer)
-            }
-            Self.logger.debug("♼ Queue: Finished enabling track for source \(source.sourceId) on renderer \(ObjectIdentifier(renderer).debugDescription)")
-        }
+        Self.logger.debug("♼ Queue: Finished enabling track for source \(source.sourceId) on renderer \(ObjectIdentifier(renderer).debugDescription)")
     }
 
-    func queueDisableTrack(for source: StreamSource) async throws {
-        guard let serialTasks = sourceToTasks[source.sourceId] else { return }
-        try await serialTasks.enqueue {
-            guard !Task.isCancelled, source.videoTrack.isActive else { return }
-            Self.logger.debug("♼ Queue: Disabling track for source \(source.sourceId)")
-            try await source.videoTrack.disable()
-            Self.logger.debug("♼ Queue: Finished disabling track for source \(source.sourceId)")
-        }
+    func disableTrack(for source: StreamSource) async throws {
+        guard !Task.isCancelled, source.videoTrack.isActive else { return }
+        Self.logger.debug("♼ Queue: Disabling track for source \(source.sourceId)")
+        try await source.videoTrack.disable()
+        Self.logger.debug("♼ Queue: Finished disabling track for source \(source.sourceId)")
     }
 }
 
@@ -235,7 +226,7 @@ final actor VideoTracksManager {
 
 private extension VideoTracksManager {
     func addSimulcastLayers(_ layers: [MCRTSRemoteTrackLayer], for source: StreamSource) async {
-        self.sourceToSimulcastLayersMapping[source.sourceId] = layers
+        sourceToSimulcastLayersMapping[source.sourceId] = layers
         Self.logger.debug("♼ Add layers \(layers.count) for \(source.sourceId)")
         let sourceId = source.sourceId
 
@@ -250,14 +241,14 @@ private extension VideoTracksManager {
         // Calculate the video quality to project from the requested list
         // Note: Only one projection can exist for a source at a given time
         let videoQualitiesRequestedForSource = activeViews
-            .compactMap { self.viewToRequestedVideoQualityMapping[$0] }
+            .compactMap { viewToRequestedVideoQualityMapping[$0] }
         let bestVideoQualityFromRequested = videoQualitiesRequestedForSource.bestVideoQualityFromTheRequestedList
         let layerToSelect = layers.matching(quality: bestVideoQualityFromRequested)
 
         let selectedVideoQuality: VideoQuality = layerToSelect == nil ? .auto : bestVideoQualityFromRequested
         let newVideoQualityAndLayerPair = VideoQualityAndLayerPair(videoQuality: selectedVideoQuality, layer: layerToSelect)
 
-        let currentVideoQualityAndLayerPair = self.sourceToSelectedVideoQualityAndLayerMapping[source.sourceId]
+        let currentVideoQualityAndLayerPair = sourceToSelectedVideoQualityAndLayerMapping[source.sourceId]
         guard newVideoQualityAndLayerPair != currentVideoQualityAndLayerPair else {
             // Currently selected video quality matches the newly calculated one, no action needed
             Self.logger.debug("♼ Exiting - Currently selected videoquality \(selectedVideoQuality.displayText) for source \(sourceId) is already up to date")
@@ -268,21 +259,21 @@ private extension VideoTracksManager {
             if let layerToSelect {
                 Self.logger.debug("♼ Has simulcast layer - \(layerToSelect) for source \(sourceId)")
                 Self.logger.debug("♼ Selecting videoquality \(selectedVideoQuality.displayText) for source \(sourceId) on view \(anyActiveView)")
-                self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
 
-                let targetBitrateForLayer = self.getBitrates(from: layerToSelect, sourceId: sourceId)
-                self.sourcedBitrates[sourceId] = targetBitrateForLayer
+                let targetBitrateForLayer = getBitrates(from: layerToSelect, sourceId: sourceId)
+                sourcedBitrates[sourceId] = targetBitrateForLayer
 
-                try await self.queueEnableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
+                try await enableTrack(for: source, layer: MCRTSRemoteVideoTrackLayer(layer: layerToSelect))
             } else {
                 Self.logger.debug("♼ No simulcast layer for source \(sourceId) matching \(bestVideoQualityFromRequested.displayText)")
                 Self.logger.debug("♼ Selecting videoquality 'Auto' for source \(sourceId) on view \(anyActiveView)")
-                self.sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
+                sourceToSelectedVideoQualityAndLayerMapping[sourceId] = newVideoQualityAndLayerPair
 
-                let targetBitrateForLayer = self.getBitrates(from: newVideoQualityAndLayerPair.layer, sourceId: sourceId)
-                self.sourcedBitrates[sourceId] = targetBitrateForLayer
+                let targetBitrateForLayer = getBitrates(from: newVideoQualityAndLayerPair.layer, sourceId: sourceId)
+                sourcedBitrates[sourceId] = targetBitrateForLayer
 
-                try await self.queueEnableTrack(for: source)
+                try await enableTrack(for: source)
             }
         } catch {
             Self.logger.debug("♼🛑 Enabling video track threw error \(error.localizedDescription)")
@@ -291,11 +282,11 @@ private extension VideoTracksManager {
 
     func removeAllStoredData(for source: StreamSource) {
         let sourceId = source.sourceId
-        let activeViews = self.sourceToActiveViewsMapping[sourceId]
+        let activeViews = sourceToActiveViewsMapping[sourceId]
 
-        activeViews?.forEach { self.viewToRequestedVideoQualityMapping[$0] = nil }
-        self.sourceToSimulcastLayersMapping[sourceId] = nil
-        self.sourceToActiveViewsMapping[sourceId] = nil
+        activeViews?.forEach { viewToRequestedVideoQualityMapping[$0] = nil }
+        sourceToSimulcastLayersMapping[sourceId] = nil
+        sourceToActiveViewsMapping[sourceId] = nil
     }
 
     func getBitrates(from layer: MCRTSRemoteTrackLayer?, sourceId: SourceID) -> LayerBitrates {
@@ -318,13 +309,13 @@ private extension VideoTracksManager {
 
 private extension VideoTracksManager {
     func addLayerEventsObservationTask(_ task: Task<Void, Never>, for source: StreamSource) {
-        self.layerEventsObservationDictionary[source.sourceId] = task
+        layerEventsObservationDictionary[source.sourceId] = task
     }
 }
 
 private extension Array where Self.Element == VideoQuality {
     var bestVideoQualityFromTheRequestedList: VideoQuality {
-        self.sorted(by: >).first ?? .auto
+        sorted(by: >).first ?? .auto
     }
 }
 

--- a/interactive-player/Interactive Viewer/Views/Settings/SettingsButton.swift
+++ b/interactive-player/Interactive Viewer/Views/Settings/SettingsButton.swift
@@ -17,6 +17,5 @@ struct SettingsButton: View {
         IconButton(iconAsset: .settings, action: {
             onAction()
         })
-        .accessibilityIdentifier("StreamingScreen.SettingButton")
     }
 }

--- a/interactive-player/Interactive Viewer/Views/SingleStream/SingleStreamView.swift
+++ b/interactive-player/Interactive Viewer/Views/SingleStream/SingleStreamView.swift
@@ -80,6 +80,7 @@ struct SingleStreamView: View {
 
             if isShowingDetailPresentation {
                 SettingsButton { isShowingSettingsScreen = true }
+                    .accessibilityIdentifier("\(SingleStreamView.self).SettingButton")
             }
         }
         .ignoresSafeArea()
@@ -93,6 +94,7 @@ struct SingleStreamView: View {
         }
         .background(Color(uiColor: theme.neutral400))
         .clipShape(Circle().inset(by: Layout.spacing0_5x))
+        .accessibilityIdentifier("\(SingleStreamView.self).CloseButton")
     }
 
     var body: some View {

--- a/interactive-player/Interactive Viewer/Views/StatsInfo/StatsInfoView.swift
+++ b/interactive-player/Interactive Viewer/Views/StatsInfo/StatsInfoView.swift
@@ -82,7 +82,7 @@ struct StatsInfoView: View {
             Text(verbatim: value, font: fontTableValue)
                 .foregroundColor(Color(theme.onBackground))
                 .frame(minWidth: Layout.spacing0x, maxWidth: .infinity, alignment: .leading)
-                .accessibilityIdentifier("Value.\(value)")
+                .accessibilityIdentifier("Value.\(title)")
                 .accessibilityValue("\(value)")
         }
         .padding([.top], Layout.spacing0_5x)

--- a/interactive-player/Interactive Viewer/Views/StreamingView/StreamingView.swift
+++ b/interactive-player/Interactive Viewer/Views/StreamingView/StreamingView.swift
@@ -168,6 +168,7 @@ struct StreamingView: View {
         }
         .background(Color(uiColor: theme.neutral400))
         .clipShape(Circle().inset(by: Layout.spacing0_5x))
+        .accessibilityIdentifier("\(StreamingView.self).CloseButton")
     }
 
     @ViewBuilder
@@ -215,7 +216,7 @@ struct StreamingView: View {
     private var settingsToolbarItem: ToolbarItem<(), some View> {
         ToolbarItem(placement: .navigationBarTrailing) {
             SettingsButton { isShowingSettingsScreen = true }
-                .accessibilityIdentifier("StreamingScreen.SettingButton")
+                .accessibilityIdentifier("\(StreamingView.self).SettingButton")
         }
     }
 


### PR DESCRIPTION
1. Fixes a crash where Track is used after a disconnect
2. Early exit if the view is not an active view for the track
3. Reuse the instance of subscriber
4. Serialise processing tracks in the order they arrive
5. Fix accessibility identifiers