### PR TITLE
Update bit rate calculation

### DIFF
--- a/LocalPackages/RTSCore/Sources/RTSCore/Manager/SubscriptionManager.swift
+++ b/LocalPackages/RTSCore/Sources/RTSCore/Manager/SubscriptionManager.swift
@@ -34,7 +34,6 @@ public actor SubscriptionManager {
     private let logHandler: MillicastLogHandler = .init()
     private var isReconnectingPeerConnection: Bool = false
     private var subscriberEventObservationTasks: [Task<Void, Never>] = []
-    private var startTime: Double?
 
     // MARK: Subscribe API methods
 
@@ -110,7 +109,6 @@ public actor SubscriptionManager {
         deregisterToSubscriberEvents()
         sourceBuilder.reset()
         logHandler.setLogFilePath(filePath: nil)
-        startTime = nil
     }
 }
 
@@ -173,7 +171,7 @@ extension SubscriptionManager {
 
         let statsObservation = Task {
             for await statsReport in subscriber.statsReport() {
-                guard !Task.isCancelled, let stats = StreamStatistics(statsReport, startTime: startTime) else {
+                guard !Task.isCancelled, let stats = StreamStatistics(statsReport) else {
                     return
                 }
                 updateStats(stats)
@@ -222,9 +220,6 @@ extension SubscriptionManager {
 private extension SubscriptionManager {
     func updateStats(_ stats: StreamStatistics) {
         streamStatistics = stats
-        if startTime == nil {
-            startTime = stats.videoStatsInboundRtpList.first?.startTime
-        }
     }
 
     func updateState(to state: State) {

--- a/interactive-player/Interactive Viewer/Views/StatsInfo/StatsInfoView.swift
+++ b/interactive-player/Interactive Viewer/Views/StatsInfo/StatsInfoView.swift
@@ -54,9 +54,6 @@ struct StatsInfoView: View {
                 ForEach(viewModel.statsItems) { item in
                     statLabel(for: item.key, value: item.value)
                 }
-
-                statLabel(for: String(localized: "stream.stats.target-bitrate.label"), value: viewModel.targetBitrate)
-                statLabel(for: String(localized: "stream.stats.outgoing-bitrate.label"), value: viewModel.outgoingBitrate)
             }
             .padding([.leading, .trailing], Layout.spacing2x)
             .padding(.bottom, Layout.spacing3x)

--- a/interactive-player/Interactive Viewer/Views/StreamingView/StreamViewModel.swift
+++ b/interactive-player/Interactive Viewer/Views/StreamingView/StreamViewModel.swift
@@ -67,7 +67,6 @@ final class StreamViewModel: ObservableObject {
     init(
         context: StreamingView.Context,
         settingsManager: SettingsManager = .shared,
-        videoTracksManager: VideoTracksManager = VideoTracksManager(),
         subscriptionManager: SubscriptionManager = SubscriptionManager()
     ) {
         self.subscriptionManager = subscriptionManager
@@ -76,7 +75,7 @@ final class StreamViewModel: ObservableObject {
         self.configuration = context.configuration
         self.listViewPrimaryVideoQuality = context.listViewPrimaryVideoQuality
         self.settingsMode = .stream(streamName: streamDetail.streamName, accountID: streamDetail.accountID)
-        self.videoTracksManager = videoTracksManager
+        self.videoTracksManager = VideoTracksManager(subscriptionManager: subscriptionManager)
 
         startObservers()
     }


### PR DESCRIPTION
1. Resets the start time of a track every time the track is unprojected 
2. Fixes Bytes per second to bps, Kbps and Mbps conversion 
3. Match frame width and frame height to fetch target and outgoing bit rates from the list of layers