### PR TITLE
Bugfix/interactive player app

### DIFF
--- a/LocalPackages/RTSCore/Sources/RTSCore/Manager/SubscriptionManager.swift
+++ b/LocalPackages/RTSCore/Sources/RTSCore/Manager/SubscriptionManager.swift
@@ -40,16 +40,19 @@ public actor SubscriptionManager {
     public init() {
         // Configure the AVAudioSession with our settings.
         AVAudioSession.configure()
-    }
-
-    public func subscribe(streamName: String, accountID: String, token: String? = nil, configuration: SubscriptionConfiguration = SubscriptionConfiguration()) async throws {
-
-        logHandler.setLogFilePath(filePath: configuration.sdkLogPath)
-
+        
         Task(priority: .userInitiated) { [weak self] in
             guard let self else { return }
             await self.registerToSubscriberEvents()
         }
+    }
+    
+    deinit {
+        deregisterToSubscriberEvents()
+    }
+
+    public func subscribe(streamName: String, accountID: String, token: String? = nil, configuration: SubscriptionConfiguration = SubscriptionConfiguration()) async throws {
+        logHandler.setLogFilePath(filePath: configuration.sdkLogPath)
 
         let subscribeTask = Task(priority: .high) { [weak subscriber] in
             guard let subscriber else { return }
@@ -106,7 +109,6 @@ public actor SubscriptionManager {
 
     private func reset() {
         state = .disconnected
-        deregisterToSubscriberEvents()
         sourceBuilder.reset()
         logHandler.setLogFilePath(filePath: nil)
     }

--- a/interactive-player/Interactive Viewer/Views/StatsInfo/StatisticsInfoViewModel.swift
+++ b/interactive-player/Interactive Viewer/Views/StatsInfo/StatisticsInfoViewModel.swift
@@ -30,13 +30,11 @@ final class StatsInfoViewModel: ObservableObject {
             let layers = await self.videoTracksManager.sourceToSimulcastLayersMapping
             let projectedTimeStampForMids = await self.videoTracksManager.projectedTimeStampForMids
             let projectedTimeStampForSource = mid.map { projectedTimeStampForMids[$0] } ?? nil
-            guard
-                let stats = await subscriptionManager.streamStatistics,
-                let layersForSource = layers[self.streamSource.sourceId]
-            else {
+            guard let stats = await subscriptionManager.streamStatistics else {
                 return
             }
 
+            let layersForSource = layers[self.streamSource.sourceId] ?? []
             self.statsItems = Self.makeStatsItems(
                 for: stats,
                 streamSource: self.streamSource,
@@ -66,11 +64,11 @@ final class StatsInfoViewModel: ObservableObject {
                     Task {
                         guard
                             let self,
-                            let stats = statistics,
-                            let layersForSource = layers[self.streamSource.sourceId]
+                            let stats = statistics
                         else {
                             return
                         }
+                        let layersForSource = layers[self.streamSource.sourceId] ?? []
                         let mid = self.streamSource.videoTrack.currentMID
                         let projectedTimeStampForMids = await self.videoTracksManager.projectedTimeStampForMids
                         let projectedTimeStampForSource = mid.map { projectedTimeStampForMids[$0] } ?? nil


### PR DESCRIPTION
1. Stats was missing when there is no layer event
2. Register and deregister to subscriber events only once. Fixes an issue where subscriber events are registered multiple times on network reconnection